### PR TITLE
GitHub Actions で CI を追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     runs-on: ubuntu-latest
@@ -15,6 +18,8 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
+        with:
+          version: 11.9.0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 26
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint / format check
+        run: pnpm check
+
+      - name: Type check
+        run: pnpm typecheck
+
+      - name: Build
+        run: pnpm build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 26
+          node-version-file: .node-version
           cache: pnpm
 
       - name: Install dependencies

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,10 +2,10 @@ import { BgColorProvider } from "@/components/BgColorProvider";
 import { Footer } from "@/components/Footer";
 import { LinkButton } from "@/components/LInkButton";
 import { Logo } from "@/components/Logo";
+import { ScrollDown } from "@/components/ScrollDown";
 import classNames from "classnames";
 import React from "react";
 import styles from "./page.module.css";
-import { ScrollDown } from "@/components/ScrollDown";
 
 export default function Home() {
   return (

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,7 +4,6 @@ import { LinkButton } from "@/components/LInkButton";
 import { Logo } from "@/components/Logo";
 import { ScrollDown } from "@/components/ScrollDown";
 import classNames from "classnames";
-import React from "react";
 import styles from "./page.module.css";
 
 export default function Home() {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "typecheck": "tsc --noEmit",
     "preview": "opennextjs-cloudflare build && opennextjs-cloudflare preview",
     "deploy": "opennextjs-cloudflare build && opennextjs-cloudflare deploy",
     "cf-typegen": "wrangler types --env-interface CloudflareEnv cloudflare-env.d.ts",


### PR DESCRIPTION
## Summary
- Lint/フォーマットチェック (`pnpm check`)、型チェック (`pnpm typecheck`)、ビルド確認 (`pnpm build`) を実行する CI ワークフローを追加
- `main` への push と PR 作成時に実行
- `package.json` に `typecheck` スクリプトを追加
- CI 導入にあたり `app/page.tsx` の既存の import 順エラーを修正

## Test plan
- [x] `pnpm check` がローカルで通ることを確認
- [x] `pnpm typecheck` がローカルで通ることを確認
- [x] `pnpm build` がローカルで通ることを確認
- [x] CI が実際に GitHub Actions 上でグリーンになることを確認